### PR TITLE
GPU device miss-match in encoder fix

### DIFF
--- a/examples/mnist/supervised_mnist.py
+++ b/examples/mnist/supervised_mnist.py
@@ -40,6 +40,7 @@ parser.add_argument("--train", dest="train", action="store_true")
 parser.add_argument("--test", dest="train", action="store_false")
 parser.add_argument("--plot", dest="plot", action="store_true")
 parser.add_argument("--gpu", dest="gpu", action="store_true")
+parser.add_argument("--device_id", type=int, default=0)
 parser.set_defaults(plot=False, gpu=False, train=True)
 
 args = parser.parse_args()
@@ -59,10 +60,12 @@ update_interval = args.update_interval
 train = args.train
 plot = args.plot
 gpu = args.gpu
+device_id = args.device_id
 
 # Sets up Gpu use
-if gpu:
-    torch.set_default_tensor_type("torch.cuda.FloatTensor")
+if gpu and torch.cuda.is_available():
+    #torch.set_default_tensor_type("torch.cuda.FloatTensor")
+    torch.cuda.set_device(device_id)
     torch.cuda.manual_seed_all(seed)
 else:
     torch.manual_seed(seed)


### PR DESCRIPTION
After changes made from issue https://github.com/BindsNET/bindsnet/issues/362 the Poisson encoder still crashed due to device miss-match. The change in this pull request is directly taken from your reservoir.py MNIST example. 
That said - it actually runs slower on my machine on GPU. Granted I have had a hard time setting up cuda on my ubuntu.