### PR TITLE
fix yticks in plot_spikes

### DIFF
--- a/bindsnet/analysis/plotting.py
+++ b/bindsnet/analysis/plotting.py
@@ -140,13 +140,13 @@ def plot_spikes(
             axes[i].set_title(
                 "%s spikes for neurons (%d - %d) from t = %d to %d " % args
             )
+            axes[i].set_yticks([n_neurons[datum[0]][0], n_neurons[datum[0]][1]])
         for ax in axes:
             ax.set_aspect("auto")
 
         plt.setp(
             axes,
             xticks=[],
-            yticks=[],
             xlabel="Simulation time",
             ylabel="Neuron index",
         )
@@ -174,6 +174,7 @@ def plot_spikes(
             axes[i].set_title(
                 "%s spikes for neurons (%d - %d) from t = %d to %d " % args
             )
+            axes[i].set_yticks([n_neurons[datum[0]][0], n_neurons[datum[0]][1]])
 
     plt.draw()
 


### PR DESCRIPTION
This adds two y axis labels to the scatter plots in `plot_spikes`, corresponding to the beginning and end of the n_neuron range. It should fix an issue uncovered in https://github.com/BindsNET/bindsnet/issues/467 that `plot_spikes`was not showing spikes for intermediate layers. The issue was that the y axis would have a small range around the spikes of the initial data entry, and this range would not cover the full span of possible neurons.

### Before
<img width="801" alt="Screen Shot 2021-04-14 at 12 02 06 AM" src="https://user-images.githubusercontent.com/6088239/114652926-e120c680-9cb4-11eb-8604-8ea694c31125.png">

### After
<img width="796" alt="Screen Shot 2021-04-14 at 12 01 31 AM" src="https://user-images.githubusercontent.com/6088239/114652923-df570300-9cb4-11eb-849e-3ba0081f3ca4.png">


