### PR TITLE
pytorch 1.7 -> 1.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ foolbox
 scipy>=1.1.0
 numpy>=1.14.2
 cython>=0.28.5
-torch==1.7.1
-torchvision==0.8.2
+torch==1.8.1
+torchvision==0.9.1
 tqdm>=4.19.9
 setuptools>=39.0.1
 matplotlib>=2.1.0

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ setup(
     zip_safe=False,
     install_requires=[
         "numpy>=1.14.2",
-        "torch==1.7.1",
-        "torchvision==0.8.2",
+        "torch==1.8.1",
+        "torchvision==0.9.1",
         "tensorboardX>=1.7",
         "tqdm>=4.19.9",
         "matplotlib>=2.1.0",


### PR DESCRIPTION
I've updated pytorch version from 1.7 to 1.8. This is needed to run pytorch with cuda11 on rtx 3080 or 3090 GPUs.