### PR TITLE
Minor changes 

### DIFF
--- a/bindsnet/learning/learning.py
+++ b/bindsnet/learning/learning.py
@@ -27,7 +27,7 @@ class LearningRule(ABC):
         nu: Optional[Union[float, Sequence[float]]] = None,
         reduction: Optional[callable] = None,
         weight_decay: float = 0.0,
-        **kwargs
+        **kwargs,
     ) -> None:
         # language=rst
         """
@@ -59,9 +59,9 @@ class LearningRule(ABC):
 
         if (self.nu == torch.zeros(2)).all() and not isinstance(self, NoOp):
             warnings.warn(
-                f"nu is set to [0., 0.] for {type(self).__name__} learning rule. " +
-                "It will disable the learning process."
-                )
+                f"nu is set to [0., 0.] for {type(self).__name__} learning rule. "
+                + "It will disable the learning process."
+            )
 
         # Parameter update reduction across minibatch dimension.
         if reduction is None:
@@ -103,7 +103,7 @@ class NoOp(LearningRule):
         nu: Optional[Union[float, Sequence[float]]] = None,
         reduction: Optional[callable] = None,
         weight_decay: float = 0.0,
-        **kwargs
+        **kwargs,
     ) -> None:
         # language=rst
         """
@@ -120,7 +120,7 @@ class NoOp(LearningRule):
             nu=nu,
             reduction=reduction,
             weight_decay=weight_decay,
-            **kwargs
+            **kwargs,
         )
 
     def update(self, **kwargs) -> None:
@@ -144,7 +144,7 @@ class PostPre(LearningRule):
         nu: Optional[Union[float, Sequence[float]]] = None,
         reduction: Optional[callable] = None,
         weight_decay: float = 0.0,
-        **kwargs
+        **kwargs,
     ) -> None:
         # language=rst
         """
@@ -162,7 +162,7 @@ class PostPre(LearningRule):
             nu=nu,
             reduction=reduction,
             weight_decay=weight_decay,
-            **kwargs
+            **kwargs,
         )
 
         assert (
@@ -260,7 +260,7 @@ class WeightDependentPostPre(LearningRule):
         nu: Optional[Union[float, Sequence[float]]] = None,
         reduction: Optional[callable] = None,
         weight_decay: float = 0.0,
-        **kwargs
+        **kwargs,
     ) -> None:
         # language=rst
         """
@@ -278,7 +278,7 @@ class WeightDependentPostPre(LearningRule):
             nu=nu,
             reduction=reduction,
             weight_decay=weight_decay,
-            **kwargs
+            **kwargs,
         )
 
         assert self.source.traces, "Pre-synaptic nodes must record spike traces."
@@ -398,7 +398,7 @@ class Hebbian(LearningRule):
         nu: Optional[Union[float, Sequence[float]]] = None,
         reduction: Optional[callable] = None,
         weight_decay: float = 0.0,
-        **kwargs
+        **kwargs,
     ) -> None:
         # language=rst
         """
@@ -416,7 +416,7 @@ class Hebbian(LearningRule):
             nu=nu,
             reduction=reduction,
             weight_decay=weight_decay,
-            **kwargs
+            **kwargs,
         )
 
         assert (
@@ -503,7 +503,7 @@ class MSTDP(LearningRule):
         nu: Optional[Union[float, Sequence[float]]] = None,
         reduction: Optional[callable] = None,
         weight_decay: float = 0.0,
-        **kwargs
+        **kwargs,
     ) -> None:
         # language=rst
         """
@@ -527,7 +527,7 @@ class MSTDP(LearningRule):
             nu=nu,
             reduction=reduction,
             weight_decay=weight_decay,
-            **kwargs
+            **kwargs,
         )
 
         if isinstance(connection, (Connection, LocalConnection)):
@@ -697,7 +697,7 @@ class MSTDPET(LearningRule):
         nu: Optional[Union[float, Sequence[float]]] = None,
         reduction: Optional[callable] = None,
         weight_decay: float = 0.0,
-        **kwargs
+        **kwargs,
     ) -> None:
         # language=rst
         """
@@ -722,7 +722,7 @@ class MSTDPET(LearningRule):
             nu=nu,
             reduction=reduction,
             weight_decay=weight_decay,
-            **kwargs
+            **kwargs,
         )
 
         if isinstance(connection, (Connection, LocalConnection)):
@@ -901,7 +901,7 @@ class Rmax(LearningRule):
         nu: Optional[Union[float, Sequence[float]]] = None,
         reduction: Optional[callable] = None,
         weight_decay: float = 0.0,
-        **kwargs
+        **kwargs,
     ) -> None:
         # language=rst
         """
@@ -926,7 +926,7 @@ class Rmax(LearningRule):
             nu=nu,
             reduction=reduction,
             weight_decay=weight_decay,
-            **kwargs
+            **kwargs,
         )
 
         # Trace is needed for computing epsilon.

--- a/bindsnet/learning/learning.py
+++ b/bindsnet/learning/learning.py
@@ -1,5 +1,6 @@
 from abc import ABC
 from typing import Union, Optional, Sequence
+import warnings
 
 import torch
 import numpy as np
@@ -55,6 +56,12 @@ class LearningRule(ABC):
         self.nu = torch.zeros(2, dtype=torch.float)
         self.nu[0] = nu[0]
         self.nu[1] = nu[1]
+
+        if (self.nu == torch.zeros(2)).all() and not isinstance(self, NoOp):
+            warnings.warn(
+                f"nu is set to [0., 0.] for {type(self).__name__} learning rule. " +
+                "It will disable the learning process."
+                )
 
         # Parameter update reduction across minibatch dimension.
         if reduction is None:
@@ -134,7 +141,7 @@ class PostPre(LearningRule):
     def __init__(
         self,
         connection: AbstractConnection,
-        nu: Optional[Union[float, Sequence[float]]] = (1e-4, 1e-2),
+        nu: Optional[Union[float, Sequence[float]]] = None,
         reduction: Optional[callable] = None,
         weight_decay: float = 0.0,
         **kwargs

--- a/bindsnet/learning/learning.py
+++ b/bindsnet/learning/learning.py
@@ -49,7 +49,7 @@ class LearningRule(ABC):
         # Learning rate(s).
         if nu is None:
             nu = [0.0, 0.0]
-        elif isinstance(nu, float) or isinstance(nu, int):
+        elif isinstance(nu, (float, int)):
             nu = [nu, nu]
 
         self.nu = torch.zeros(2, dtype=torch.float)
@@ -134,7 +134,7 @@ class PostPre(LearningRule):
     def __init__(
         self,
         connection: AbstractConnection,
-        nu: Optional[Union[float, Sequence[float]]] = None,
+        nu: Optional[Union[float, Sequence[float]]] = (1e-4, 1e-2),
         reduction: Optional[callable] = None,
         weight_decay: float = 0.0,
         **kwargs
@@ -788,7 +788,7 @@ class MSTDPET(LearningRule):
         self.p_minus += a_minus * target_s
 
         # Calculate point eligibility value.
-        self.eligibility = torch.ger(self.p_plus, target_s) + torch.ger(
+        self.eligibility = torch.outer(self.p_plus, target_s) + torch.outer(
             source_s, self.p_minus
         )
 

--- a/bindsnet/models/models.py
+++ b/bindsnet/models/models.py
@@ -391,7 +391,7 @@ class IncreasingInhibitionNetwork(Network):
         )
         self.add_connection(input_output_conn, source="X", target="Y")
 
-        # add internal inhibetory connections
+        # add internal inhibitory connections
         w = torch.ones(self.n_neurons, self.n_neurons) - torch.diag(
             torch.ones(self.n_neurons)
         )

--- a/bindsnet/network/network.py
+++ b/bindsnet/network/network.py
@@ -231,7 +231,7 @@ class Network(torch.nn.Module):
                             self.batch_size,
                             target.res_window_size,
                             *target.shape,
-                            device=target.s.device
+                            device=target.s.device,
                         )
                     else:
                         inputs[c[1]] = torch.zeros(
@@ -308,8 +308,9 @@ class Network(torch.nn.Module):
             plt.show()
         """
         # Check input type
-        assert type(inputs) == dict, ("'inputs' must be a dict of names of layers " + 
-        f"(str) and relevant input tensors. Got {type(inputs).__name__} instead."
+        assert type(inputs) == dict, (
+            "'inputs' must be a dict of names of layers "
+            + f"(str) and relevant input tensors. Got {type(inputs).__name__} instead."
         )
         # Parse keyword arguments.
         clamps = kwargs.get("clamp", {})

--- a/bindsnet/network/network.py
+++ b/bindsnet/network/network.py
@@ -2,7 +2,6 @@ import tempfile
 from typing import Dict, Optional, Type, Iterable
 
 import torch
-from tqdm import tqdm
 
 from .monitors import AbstractMonitor
 from .nodes import Nodes, CSRMNodes
@@ -353,9 +352,7 @@ class Network(torch.nn.Module):
         timesteps = int(time / self.dt)
 
         # Simulate network activity for `time` timesteps.
-        for t in (tqdm(range(timesteps)) if kwargs.get('progress_bar', False)
-        else range(timesteps)
-        ):
+        for t in range(timesteps):
             # Get input to all layers (synchronous mode).
             current_inputs = {}
             if not one_step:

--- a/bindsnet/network/nodes.py
+++ b/bindsnet/network/nodes.py
@@ -101,7 +101,7 @@ class Nodes(torch.nn.Module):
             if self.traces_additive:
                 self.x += self.trace_scale * self.s.float()
             else:
-                self.x.masked_fill_(self.s.bool(), 1)
+                self.x.masked_fill_(self.s.bool(), self.trace_scale)
 
         if self.sum_input:
             # Add current input to running sum.
@@ -1538,7 +1538,7 @@ class CSRMNodes(Nodes):
 
     def RectangularKernel(self, dt):
         t = torch.arange(0, self.res_window_size, dt)
-        kernelVec = 1 / (selftau * 2)
+        kernelVec = 1 / (self.tau * 2)
         return torch.flip(kernelVec, [0])
 
     def TriangularKernel(self, dt):

--- a/bindsnet/network/nodes.py
+++ b/bindsnet/network/nodes.py
@@ -70,10 +70,9 @@ class Nodes(torch.nn.Module):
             self.register_buffer(
                 "tc_trace", torch.tensor(tc_trace)
             )  # Time constant of spike trace decay.
-            if self.traces_additive:
-                self.register_buffer(
-                    "trace_scale", torch.tensor(trace_scale)
-                )  # Scaling factor for spike trace.
+            self.register_buffer(
+                "trace_scale", torch.tensor(trace_scale)
+            )  # Scaling factor for spike trace.
             self.register_buffer(
                 "trace_decay", torch.empty_like(self.tc_trace)
             )  # Set in compute_decays.


### PR DESCRIPTION
A few suggestions:
- `Nodes:` When `traces_additive` is False, spike trace (self.x) would be filled with 1 at spike points. However, it is not always the case (For example in Izhikevich 2007, this value is set to 0.1). I think the 1 is better to be replaced by the `trace_scale` value, so users can set this value as well.
- `Nodes:` typo: `self.tau`
- `Learning: `the default value for `nu` is set to `None`, which makes the `PostPre` learning rule practically wasteful. I believe it is not a good default value for an argument and it is better to be replaced by some float numbers or get changed to a mandatory argument.
- `Network:` the format of the `inputs` argument of the `run` method is not very common and since the input in most of the deep learning frameworks (mainly TensorFlow and Pytorch) is in the type of tensors, it can be tricky especially for new users. Furthermore, since there is no explicit error to point out this problem, it could be sometimes hard to find and a time-consuming error. Adding an assert to check the type of `inputs` can be helpful in this regard.
- `Network:` A progress bar can be useful in very long runs A custom progress bar (including some information about the run and the network) can be added later.
- `Learning:` replace `torch.ger` with `torch.outer` (https://pytorch.org/docs/stable/generated/torch.ger.html)
- `models:` typo: `inhibitory`

@Hananel-Hazan