### PR TITLE
Fix WeightDependentPostPre Post-synaptic update

### DIFF
--- a/bindsnet/learning/learning.py
+++ b/bindsnet/learning/learning.py
@@ -538,7 +538,7 @@ class WeightDependentPostPre(LearningRule):
             update += (
                 self.nu[1]
                 * post.view(self.connection.w.size())
-                * (self.wmax - self.connection.wmin)
+                * (self.wmax - self.connection.w)
             )
 
         self.connection.w += update

--- a/bindsnet/learning/learning.py
+++ b/bindsnet/learning/learning.py
@@ -611,7 +611,7 @@ class WeightDependentPostPre(LearningRule):
             update += (
                 self.nu[1]
                 * post.view(self.connection.w.size())
-                * (self.wmax - self.connection.wmin)
+                * (self.wmax - self.connection.w)
             )
 
         self.connection.w += update


### PR DESCRIPTION
The difference of `wmax` and the actual weights had been mistakenly calculated as `(self.wmax - self.connection.wmin)`, which was a fixed value.