### PR TITLE
Vectorial learning rates for all UpdateRules.

### DIFF
--- a/bindsnet/learning/learning.py
+++ b/bindsnet/learning/learning.py
@@ -39,7 +39,7 @@ class LearningRule(ABC):
         # language=rst
         """
         Abstract constructor for the ``LearningRule`` object.
-        
+
         :param connection: An ``AbstractConnection`` object.
         :param nu: Single or pair of learning rates for pre- and post-synaptic events. It also
             accepts a pair of tensors to individualize learning rates of each neuron.
@@ -55,7 +55,7 @@ class LearningRule(ABC):
 
         self.wmin = connection.wmin
         self.wmax = connection.wmax
-        
+
         # Learning rate(s).
         if nu is None:
             self.nu = torch.tensor([0.0, 0.0], dtype=torch.float)
@@ -118,7 +118,7 @@ class NoOp(LearningRule):
         # language=rst
         """
         Abstract constructor for the ``LearningRule`` object.
-        
+
         :param connection: An ``AbstractConnection`` object.
         :param nu: Single or pair of learning rates for pre- and post-synaptic events. It also
             accepts a pair of tensors to individualize learning rates of each neuron.
@@ -161,7 +161,7 @@ class PostPre(LearningRule):
         # language=rst
         """
         Constructor for ``PostPre`` learning rule.
-        
+
         :param connection: An ``AbstractConnection`` object whose weights the
             ``PostPre`` learning rule will modify.
         :param nu: Single or pair of learning rates for pre- and post-synaptic events. It also
@@ -569,7 +569,7 @@ class WeightDependentPostPre(LearningRule):
         # language=rst
         """
         Constructor for ``WeightDependentPostPre`` learning rule.
-        
+
         :param connection: An ``AbstractConnection`` object whose weights the
             ``WeightDependentPostPre`` learning rule will modify.
         :param nu: Single or pair of learning rates for pre- and post-synaptic events. It also
@@ -1057,7 +1057,7 @@ class Hebbian(LearningRule):
         # language=rst
         """
         Constructor for ``Hebbian`` learning rule.
-        
+
         :param connection: An ``AbstractConnection`` object whose weights the
             ``Hebbian`` learning rule will modify.
         :param nu: Single or pair of learning rates for pre- and post-synaptic events. It also
@@ -1443,7 +1443,7 @@ class MSTDP(LearningRule):
         # language=rst
         """
         Constructor for ``MSTDP`` learning rule.
-        
+
         :param connection: An ``AbstractConnection`` object whose weights the ``MSTDP``
             learning rule will modify.
         :param nu: Single or pair of learning rates for pre- and post-synaptic events, respectively. It also
@@ -1452,9 +1452,9 @@ class MSTDP(LearningRule):
         :param reduction: Method for reducing parameter updates along the minibatch
             dimension.
         :param weight_decay: Coefficient controlling rate of decay of the weights each iteration.
-        
+
         Keyword arguments:
-        
+
         :param tc_plus: Time constant for pre-synaptic firing trace.
         :param tc_minus: Time constant for post-synaptic firing trace.
         """
@@ -1492,9 +1492,9 @@ class MSTDP(LearningRule):
         # language=rst
         """
         MSTDP learning rule for ``Connection`` subclass of ``AbstractConnection`` class.
-        
+
         Keyword arguments:
-        
+
         :param Union[float, torch.Tensor] reward: Reward signal from reinforcement
             learning task.
         :param float a_plus: Learning rate (post-synaptic).
@@ -1849,9 +1849,9 @@ class MSTDP(LearningRule):
         """
         MSTDP learning rule for ``Conv1dConnection`` subclass of ``AbstractConnection``
         class.
-        
+
         Keyword arguments:
-        
+
         :param Union[float, torch.Tensor] reward: Reward signal from reinforcement
             learning task.
         :param float a_plus: Learning rate (post-synaptic).
@@ -1923,9 +1923,9 @@ class MSTDP(LearningRule):
         """
         MSTDP learning rule for ``Conv2dConnection`` subclass of ``AbstractConnection``
         class.
-        
+
         Keyword arguments:
-        
+
         :param Union[float, torch.Tensor] reward: Reward signal from reinforcement
             learning task.
         :param float a_plus: Learning rate (post-synaptic).
@@ -1998,9 +1998,9 @@ class MSTDP(LearningRule):
         """
         MSTDP learning rule for ``Conv3dConnection`` subclass of ``AbstractConnection``
         class.
-        
+
         Keyword arguments:
-        
+
         :param Union[float, torch.Tensor] reward: Reward signal from reinforcement
             learning task.
         :param float a_plus: Learning rate (post-synaptic).
@@ -2118,7 +2118,7 @@ class MSTDPET(LearningRule):
         # language=rst
         """
         Constructor for ``MSTDPET`` learning rule.
-        
+
         :param connection: An ``AbstractConnection`` object whose weights the
             ``MSTDPET`` learning rule will modify.
         :param nu: Single or pair of learning rates for pre- and post-synaptic events, respectively. It also
@@ -2168,9 +2168,9 @@ class MSTDPET(LearningRule):
         """
         MSTDPET learning rule for ``Connection`` subclass of ``AbstractConnection``
         class.
-        
+
         Keyword arguments:
-        
+
         :param Union[float, torch.Tensor] reward: Reward signal from reinforcement
             learning task.
         :param float a_plus: Learning rate (post-synaptic).
@@ -2551,9 +2551,9 @@ class MSTDPET(LearningRule):
         """
         MSTDPET learning rule for ``Conv1dConnection`` subclass of
         ``AbstractConnection`` class.
-        
+
         Keyword arguments:
-        
+
         :param Union[float, torch.Tensor] reward: Reward signal from reinforcement
             learning task.
         :param float a_plus: Learning rate (post-synaptic).
@@ -2634,9 +2634,9 @@ class MSTDPET(LearningRule):
         """
         MSTDPET learning rule for ``Conv2dConnection`` subclass of
         ``AbstractConnection`` class.
-        
+
         Keyword arguments:
-        
+
         :param Union[float, torch.Tensor] reward: Reward signal from reinforcement
             learning task.
         :param float a_plus: Learning rate (post-synaptic).
@@ -2719,9 +2719,9 @@ class MSTDPET(LearningRule):
         """
         MSTDPET learning rule for ``Conv3dConnection`` subclass of
         ``AbstractConnection`` class.
-        
+
         Keyword arguments:
-        
+
         :param Union[float, torch.Tensor] reward: Reward signal from reinforcement
             learning task.
         :param float a_plus: Learning rate (post-synaptic).
@@ -2852,7 +2852,7 @@ class Rmax(LearningRule):
         # language=rst
         """
         Constructor for ``R-max`` learning rule.
-        
+
         :param connection: An ``AbstractConnection`` object whose weights the ``R-max``
             learning rule will modify.
         :param nu: Single or pair of learning rates for pre- and post-synaptic events, respectively. It also
@@ -2861,9 +2861,9 @@ class Rmax(LearningRule):
         :param reduction: Method for reducing parameter updates along the minibatch
             dimension.
         :param weight_decay: Coefficient controlling rate of decay of the weights each iteration.
-        
+
         Keyword arguments:
-        
+
         :param float tc_c: Time constant for balancing naive Hebbian and policy gradient
             learning.
         :param float tc_e_trace: Time constant for the eligibility trace.
@@ -2902,9 +2902,9 @@ class Rmax(LearningRule):
         # language=rst
         """
         R-max learning rule for ``Connection`` subclass of ``AbstractConnection`` class.
-        
+
         Keyword arguments:
-        
+
         :param Union[float, torch.Tensor] reward: Reward signal from reinforcement
             learning task.
         """

--- a/bindsnet/network/topology.py
+++ b/bindsnet/network/topology.py
@@ -21,7 +21,7 @@ class AbstractConnection(ABC, Module):
         self,
         source: Nodes,
         target: Nodes,
-        nu: Optional[Union[float, Sequence[float]]] = None,
+        nu: Optional[Union[float, Sequence[float], Sequence[torch.Tensor]]] = None,
         reduction: Optional[callable] = None,
         weight_decay: float = 0.0,
         **kwargs,
@@ -32,7 +32,9 @@ class AbstractConnection(ABC, Module):
 
         :param source: A layer of nodes from which the connection originates.
         :param target: A layer of nodes to which the connection connects.
-        :param nu: Learning rate for both pre- and post-synaptic events.
+         :param nu: Learning rate for both pre- and post-synaptic events. It also
+            accepts a pair of tensors to individualize learning rates of each neuron.
+            In this case, their shape should be the same size as the connection weights.
         :param reduction: Method for reducing parameter updates along the minibatch
             dimension.
         :param weight_decay: Constant multiple to decay weights by on each iteration.
@@ -133,7 +135,7 @@ class Connection(AbstractConnection):
         self,
         source: Nodes,
         target: Nodes,
-        nu: Optional[Union[float, Sequence[float]]] = None,
+        nu: Optional[Union[float, Sequence[float], Sequence[torch.Tensor]]] = None,
         reduction: Optional[callable] = None,
         weight_decay: float = 0.0,
         **kwargs,
@@ -144,7 +146,9 @@ class Connection(AbstractConnection):
 
         :param source: A layer of nodes from which the connection originates.
         :param target: A layer of nodes to which the connection connects.
-        :param nu: Learning rate for both pre- and post-synaptic events.
+         :param nu: Learning rate for both pre- and post-synaptic events. It also
+            accepts a pair of tensors to individualize learning rates of each neuron.
+            In this case, their shape should be the same size as the connection weights.
         :param reduction: Method for reducing parameter updates along the minibatch
             dimension.
         :param weight_decay: Constant multiple to decay weights by on each iteration.
@@ -268,7 +272,7 @@ class Conv1dConnection(AbstractConnection):
         stride: int = 1,
         padding: int = 0,
         dilation: int = 1,
-        nu: Optional[Union[float, Sequence[float]]] = None,
+        nu: Optional[Union[float, Sequence[float], Sequence[torch.Tensor]]] = None,
         reduction: Optional[callable] = None,
         weight_decay: float = 0.0,
         **kwargs,
@@ -283,7 +287,9 @@ class Conv1dConnection(AbstractConnection):
         :param stride: stride for convolution.
         :param padding: padding for convolution.
         :param dilation: dilation for convolution.
-        :param nu: Learning rate for both pre- and post-synaptic events.
+         :param nu: Learning rate for both pre- and post-synaptic events. It also
+            accepts a pair of tensors to individualize learning rates of each neuron.
+            In this case, their shape should be the same size as the connection weights.
         :param reduction: Method for reducing parameter updates along the minibatch
             dimension.
         :param weight_decay: Constant multiple to decay weights by on each iteration.
@@ -408,7 +414,7 @@ class Conv2dConnection(AbstractConnection):
         stride: Union[int, Tuple[int, int]] = 1,
         padding: Union[int, Tuple[int, int]] = 0,
         dilation: Union[int, Tuple[int, int]] = 1,
-        nu: Optional[Union[float, Sequence[float]]] = None,
+        nu: Optional[Union[float, Sequence[float], Sequence[torch.Tensor]]] = None,
         reduction: Optional[callable] = None,
         weight_decay: float = 0.0,
         **kwargs,
@@ -423,7 +429,9 @@ class Conv2dConnection(AbstractConnection):
         :param stride: Horizontal and vertical stride for convolution.
         :param padding: Horizontal and vertical padding for convolution.
         :param dilation: Horizontal and vertical dilation for convolution.
-        :param nu: Learning rate for both pre- and post-synaptic events.
+         :param nu: Learning rate for both pre- and post-synaptic events. It also
+            accepts a pair of tensors to individualize learning rates of each neuron.
+            In this case, their shape should be the same size as the connection weights.
         :param reduction: Method for reducing parameter updates along the minibatch
             dimension.
         :param weight_decay: Constant multiple to decay weights by on each iteration.
@@ -563,7 +571,7 @@ class Conv3dConnection(AbstractConnection):
         stride: Union[int, Tuple[int, int, int]] = 1,
         padding: Union[int, Tuple[int, int, int]] = 0,
         dilation: Union[int, Tuple[int, int, int]] = 1,
-        nu: Optional[Union[float, Sequence[float]]] = None,
+        nu: Optional[Union[float, Sequence[float], Sequence[torch.Tensor]]] = None,
         reduction: Optional[callable] = None,
         weight_decay: float = 0.0,
         **kwargs,
@@ -578,7 +586,9 @@ class Conv3dConnection(AbstractConnection):
         :param stride: Depth-wise, horizontal, and vertical stride for convolution.
         :param padding: Depth-wise, horizontal, and vertical  padding for convolution.
         :param dilation: Depth-wise, horizontal and vertical dilation for convolution.
-        :param nu: Learning rate for both pre- and post-synaptic events.
+         :param nu: Learning rate for both pre- and post-synaptic events. It also
+            accepts a pair of tensors to individualize learning rates of each neuron.
+            In this case, their shape should be the same size as the connection weights.
         :param reduction: Method for reducing parameter updates along the minibatch
             dimension.
         :param weight_decay: Constant multiple to decay weights by on each iteration.
@@ -1007,7 +1017,7 @@ class LocalConnection(AbstractConnection):
         kernel_size: Union[int, Tuple[int, int]],
         stride: Union[int, Tuple[int, int]],
         n_filters: int,
-        nu: Optional[Union[float, Sequence[float]]] = None,
+        nu: Optional[Union[float, Sequence[float], Sequence[torch.Tensor]]] = None,
         reduction: Optional[callable] = None,
         weight_decay: float = 0.0,
         **kwargs,
@@ -1027,7 +1037,9 @@ class LocalConnection(AbstractConnection):
         :param kernel_size: Horizontal and vertical size of convolutional kernels.
         :param stride: Horizontal and vertical stride for convolution.
         :param n_filters: Number of locally connected filters per pre-synaptic region.
-        :param nu: Learning rate for both pre- and post-synaptic events.
+         :param nu: Learning rate for both pre- and post-synaptic events. It also
+            accepts a pair of tensors to individualize learning rates of each neuron.
+            In this case, their shape should be the same size as the connection weights.
         :param reduction: Method for reducing parameter updates along the minibatch
             dimension.
         :param weight_decay: Constant multiple to decay weights by on each iteration.
@@ -1185,7 +1197,7 @@ class LocalConnection1D(AbstractConnection):
         kernel_size: int,
         stride: int,
         n_filters: int,
-        nu: Optional[Union[float, Sequence[float]]] = None,
+        nu: Optional[Union[float, Sequence[float], Sequence[torch.Tensor]]] = None,
         reduction: Optional[callable] = None,
         weight_decay: float = 0.0,
         **kwargs,
@@ -1201,7 +1213,9 @@ class LocalConnection1D(AbstractConnection):
         :param kernel_size: size of convolutional kernels.
         :param stride: stride for convolution.
         :param n_filters: Number of locally connected filters per pre-synaptic region.
-        :param nu: Learning rate for both pre- and post-synaptic events.
+         :param nu: Learning rate for both pre- and post-synaptic events. It also
+            accepts a pair of tensors to individualize learning rates of each neuron.
+            In this case, their shape should be the same size as the connection weights.
         :param reduction: Method for reducing parameter updates along the minibatch dimension.
         :param weight_decay: Constant multiple to decay weights by on each iteration.
         Keyword arguments:
@@ -1315,7 +1329,7 @@ class LocalConnection2D(AbstractConnection):
         kernel_size: Union[int, Tuple[int, int]],
         stride: Union[int, Tuple[int, int]],
         n_filters: int,
-        nu: Optional[Union[float, Sequence[float]]] = None,
+        nu: Optional[Union[float, Sequence[float], Sequence[torch.Tensor]]] = None,
         reduction: Optional[callable] = None,
         weight_decay: float = 0.0,
         **kwargs,
@@ -1331,7 +1345,9 @@ class LocalConnection2D(AbstractConnection):
         :param kernel_size: Horizontal and vertical size of convolutional kernels.
         :param stride: Horizontal and vertical stride for convolution.
         :param n_filters: Number of locally connected filters per pre-synaptic region.
-        :param nu: Learning rate for both pre- and post-synaptic events.
+         :param nu: Learning rate for both pre- and post-synaptic events. It also
+            accepts a pair of tensors to individualize learning rates of each neuron.
+            In this case, their shape should be the same size as the connection weights.
         :param reduction: Method for reducing parameter updates along the minibatch dimension.
         :param weight_decay: Constant multiple to decay weights by on each iteration.
         Keyword arguments:
@@ -1456,7 +1472,7 @@ class LocalConnection3D(AbstractConnection):
         kernel_size: Union[int, Tuple[int, int, int]],
         stride: Union[int, Tuple[int, int, int]],
         n_filters: int,
-        nu: Optional[Union[float, Sequence[float]]] = None,
+        nu: Optional[Union[float, Sequence[float], Sequence[torch.Tensor]]] = None,
         reduction: Optional[callable] = None,
         weight_decay: float = 0.0,
         **kwargs,
@@ -1472,7 +1488,9 @@ class LocalConnection3D(AbstractConnection):
         :param kernel_size: Horizontal, vertical, and depth-wise size of convolutional kernels.
         :param stride: Horizontal, vertical, and depth-wise stride for convolution.
         :param n_filters: Number of locally connected filters per pre-synaptic region.
-        :param nu: Learning rate for both pre- and post-synaptic events.
+         :param nu: Learning rate for both pre- and post-synaptic events. It also
+            accepts a pair of tensors to individualize learning rates of each neuron.
+            In this case, their shape should be the same size as the connection weights.
         :param reduction: Method for reducing parameter updates along the minibatch dimension.
         :param weight_decay: Constant multiple to decay weights by on each iteration.
         Keyword arguments:
@@ -1599,7 +1617,7 @@ class MeanFieldConnection(AbstractConnection):
         self,
         source: Nodes,
         target: Nodes,
-        nu: Optional[Union[float, Sequence[float]]] = None,
+        nu: Optional[Union[float, Sequence[float], Sequence[torch.Tensor]]] = None,
         weight_decay: float = 0.0,
         **kwargs,
     ) -> None:
@@ -1608,7 +1626,9 @@ class MeanFieldConnection(AbstractConnection):
         Instantiates a :code:`MeanFieldConnection` object.
         :param source: A layer of nodes from which the connection originates.
         :param target: A layer of nodes to which the connection connects.
-        :param nu: Learning rate for both pre- and post-synaptic events.
+         :param nu: Learning rate for both pre- and post-synaptic events. It also
+            accepts a pair of tensors to individualize learning rates of each neuron.
+            In this case, their shape should be the same size as the connection weights.
         :param weight_decay: Constant multiple to decay weights by on each iteration.
         Keyword arguments:
         :param LearningRule update_rule: Modifies connection parameters according to
@@ -1681,7 +1701,7 @@ class SparseConnection(AbstractConnection):
         self,
         source: Nodes,
         target: Nodes,
-        nu: Optional[Union[float, Sequence[float]]] = None,
+        nu: Optional[Union[float, Sequence[float], Sequence[torch.Tensor]]] = None,
         reduction: Optional[callable] = None,
         weight_decay: float = None,
         **kwargs,
@@ -1692,7 +1712,9 @@ class SparseConnection(AbstractConnection):
 
         :param source: A layer of nodes from which the connection originates.
         :param target: A layer of nodes to which the connection connects.
-        :param nu: Learning rate for both pre- and post-synaptic events.
+         :param nu: Learning rate for both pre- and post-synaptic events. It also
+            accepts a pair of tensors to individualize learning rates of each neuron.
+            In this case, their shape should be the same size as the connection weights.
         :param reduction: Method for reducing parameter updates along the minibatch
             dimension.
         :param weight_decay: Constant multiple to decay weights by on each iteration.


### PR DESCRIPTION
:param nu: Single or pair of learning rates for pre- and post-synaptic events. It also accepts a pair of tensors to individualize learning rates of each neuron. In this case, their shape should be the same size as the connection weights.