### PR TITLE
Squeeze spike record sum to compute softmax on the correct dimension

### DIFF
--- a/bindsnet/pipeline/action.py
+++ b/bindsnet/pipeline/action.py
@@ -76,7 +76,7 @@ def select_softmax(pipeline: EnvironmentPipeline, **kwargs) -> int:
         pipeline, "spike_record"
     ), "EnvironmentPipeline is missing the attribute: spike_record."
 
-    spikes = torch.sum(pipeline.spike_record[output], dim=0)
+    spikes = torch.sum(pipeline.spike_record[output], dim=0).squeeze()
     probabilities = torch.softmax(spikes, dim=0)
     return torch.multinomial(probabilities, num_samples=1).item()
 


### PR DESCRIPTION
see [here](https://github.com/BindsNET/bindsnet/issues/577) for further info. 