### PR TITLE
Small bug in environment_pipeline when action_counter > random_action_after

### DIFF
--- a/bindsnet/pipeline/environment_pipeline.py
+++ b/bindsnet/pipeline/environment_pipeline.py
@@ -177,7 +177,7 @@ class EnvironmentPipeline(BasePipeline):
                 else:
                     self.action = torch.randint(
                         low=0, high=self.env.action_space.n, size=(1,)
-                    )[0]
+                    )[0].item()
                     tqdm.write(f"too many times {self.last_action} ")
             else:
                 self.action = self.action_function(self, output=self.output)


### PR DESCRIPTION
If `.item()` is not specified, `self.action` will be a `torch.tensor` object. However, `self.env.step(self.action)` few lines later does not accept a tensor and it will break, therefore `.item()` is needed (as in other parts of the code when the action is computed).

- I also created this general-named branch in case I find new things to add, instead of creating a new branch for each little thing. Hope that's ok. 