### PR TITLE
Remove unused argument `input_time_dim`

### DIFF
--- a/examples/mnist/SOM_LM-SNNs.py
+++ b/examples/mnist/SOM_LM-SNNs.py
@@ -253,7 +253,7 @@ for epoch in range(n_epochs):
         factor = 1.2
         for retry in range(5):
             # Run the network on the input.
-            network.run(inputs=inputs, time=time, input_time_dim=1)
+            network.run(inputs=inputs, time=time)
 
             # Get spikes from the network
             temp_spikes = spikes["Y"].get("s").squeeze()
@@ -348,7 +348,7 @@ for step, batch in enumerate(test_dataset):
         inputs = {k: v.cuda() for k, v in inputs.items()}
 
     # Run the network on the input.
-    network.run(inputs=inputs, time=time, input_time_dim=1)
+    network.run(inputs=inputs, time=time)
 
     # Add to spikes recording.
     spike_record[0] = spikes["Y"].get("s").squeeze()

--- a/examples/mnist/batch_eth_mnist.py
+++ b/examples/mnist/batch_eth_mnist.py
@@ -252,7 +252,7 @@ for epoch in range(n_epochs):
         labels.extend(batch["label"].tolist())
 
         # Run the network on the input.
-        network.run(inputs=inputs, time=time, input_time_dim=1)
+        network.run(inputs=inputs, time=time)
 
         # Add to spikes recording.
         s = spikes["Ae"].get("s").permute((1, 0, 2))
@@ -343,7 +343,7 @@ for step, batch in enumerate(test_dataloader):
         inputs = {k: v.cuda() for k, v in inputs.items()}
 
     # Run the network on the input.
-    network.run(inputs=inputs, time=time, input_time_dim=1)
+    network.run(inputs=inputs, time=time)
 
     # Add to spikes recording.
     spike_record = spikes["Ae"].get("s").permute((1, 0, 2))

--- a/examples/mnist/conv1d_MNIST.py
+++ b/examples/mnist/conv1d_MNIST.py
@@ -174,7 +174,7 @@ for epoch in range(n_epochs):
         label = batch["label"]
 
         # Run the network on the input.
-        network.run(inputs=inputs, time=time, input_time_dim=1)
+        network.run(inputs=inputs, time=time)
 
         network.reset_state_variables()  # Reset state variables.
 

--- a/examples/mnist/conv3d_MNIST.py
+++ b/examples/mnist/conv3d_MNIST.py
@@ -199,7 +199,7 @@ for epoch in range(n_epochs):
         label = batch["label"]
 
         # Run the network on the input.
-        network.run(inputs=inputs, time=time, input_time_dim=1)
+        network.run(inputs=inputs, time=time)
 
         network.reset_state_variables()  # Reset state variables.
 

--- a/examples/mnist/conv_mnist.py
+++ b/examples/mnist/conv_mnist.py
@@ -183,7 +183,7 @@ for epoch in range(n_epochs):
         label = batch["label"]
 
         # Run the network on the input.
-        network.run(inputs=inputs, time=time, input_time_dim=1)
+        network.run(inputs=inputs, time=time)
 
         # Optionally plot various simulation information.
         if plot and batch_size == 1:

--- a/examples/mnist/eth_mnist.py
+++ b/examples/mnist/eth_mnist.py
@@ -240,7 +240,7 @@ for epoch in range(n_epochs):
         labels.append(batch["label"])
 
         # Run the network on the input.
-        network.run(inputs=inputs, time=time, input_time_dim=1)
+        network.run(inputs=inputs, time=time)
 
         # Get voltage recording.
         exc_voltages = exc_voltage_monitor.get("v")
@@ -312,7 +312,7 @@ for step, batch in enumerate(test_dataset):
         inputs = {k: v.cuda() for k, v in inputs.items()}
 
     # Run the network on the input.
-    network.run(inputs=inputs, time=time, input_time_dim=1)
+    network.run(inputs=inputs, time=time)
 
     # Add to spikes recording.
     spike_record[0] = spikes["Ae"].get("s").squeeze()

--- a/examples/mnist/loc1d_mnist.py
+++ b/examples/mnist/loc1d_mnist.py
@@ -161,7 +161,7 @@ for epoch in range(n_epochs):
         label = batch["label"]
 
         # Run the network on the input.
-        network.run(inputs=inputs, time=time, input_time_dim=1)
+        network.run(inputs=inputs, time=time)
 
         network.reset_state_variables()  # Reset state variables.
 

--- a/examples/mnist/loc2d_mnist.py
+++ b/examples/mnist/loc2d_mnist.py
@@ -176,7 +176,7 @@ for epoch in range(n_epochs):
         label = batch["label"]
 
         # Run the network on the input.
-        network.run(inputs=inputs, time=time, input_time_dim=1)
+        network.run(inputs=inputs, time=time)
 
         # Optionally plot various simulation information.
         if plot:

--- a/examples/mnist/loc3d_mnist.py
+++ b/examples/mnist/loc3d_mnist.py
@@ -186,7 +186,7 @@ for epoch in range(n_epochs):
         label = batch["label"]
 
         # Run the network on the input.
-        network.run(inputs=inputs, time=time, input_time_dim=1)
+        network.run(inputs=inputs, time=time)
 
 
 print("Progress: %d / %d (%.4f seconds)\n" % (n_epochs, n_epochs, t() - start))

--- a/examples/mnist/reservoir.py
+++ b/examples/mnist/reservoir.py
@@ -139,7 +139,7 @@ for (i, dataPoint) in pbar:
     pbar.set_description_str("Train progress: (%d / %d)" % (i, n_iters))
 
     # Run network on sample image
-    network.run(inputs={"I": datum}, time=time, input_time_dim=1)
+    network.run(inputs={"I": datum}, time=time)
     training_pairs.append([spikes["O"].get("s").sum(0), label])
 
     # Plot spiking activity using monitors
@@ -237,7 +237,7 @@ for (i, dataPoint) in pbar:
     label = dataPoint["label"]
     pbar.set_description_str("Testing progress: (%d / %d)" % (i, n_iters))
 
-    network.run(inputs={"I": datum}, time=time, input_time_dim=1)
+    network.run(inputs={"I": datum}, time=time)
     test_pairs.append([spikes["O"].get("s").sum(0), label])
 
     if plot:

--- a/examples/mnist/supervised_mnist.py
+++ b/examples/mnist/supervised_mnist.py
@@ -281,7 +281,7 @@ for step, batch in enumerate(test_dataset):
         inputs = {k: v.cuda() for k, v in inputs.items()}
 
     # Run the network on the input.
-    network.run(inputs=inputs, time=time, input_time_dim=1)
+    network.run(inputs=inputs, time=time)
 
     # Add to spikes recording.
     spike_record[0] = spikes["Ae"].get("s").squeeze()

--- a/examples/tensorboard/tensorboard.py
+++ b/examples/tensorboard/tensorboard.py
@@ -114,7 +114,7 @@ for step, batch in enumerate(tqdm(train_dataloader)):
 
     # Run the network on the input.
     # Specify the location of the time dimension
-    network.run(inputs=inputs, time=time, input_time_dim=1)
+    network.run(inputs=inputs, time=time)
 
     network.reset_state_variables()  # Reset state variables.
 


### PR DESCRIPTION
`input_time_dim=1` is used througout the examples but never eventually used (error never occurs because it is eventually absorbed in some `kwargs`). Removing it to avoid confusion.