### PR TITLE
docs: Update README badges - Collaboration Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Check out the [BindsNET examples](https://github.com/BindsNET/bindsnet/tree/mast
 ![Build Status](https://github.com/BindsNET/bindsnet/actions/workflows/python-app.yml/badge.svg?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/bindsnet-docs/badge/?version=latest)](https://bindsnet-docs.readthedocs.io/?badge=latest)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/bindsnet_/community)
+[![Neuromorphic Computing](https://img.shields.io/badge/Community-Open_Neuromorphic-blue)](https://open-neuromorphic.org/neuromorphic-computing/)
 
 ## Requirements
 


### PR DESCRIPTION
I adjusted it a bit so that it is the same size as the other badges in the README.md

<img width="1035" height="513" alt="image" src="https://github.com/user-attachments/assets/47dfb702-bda1-415d-8182-985919786b05" />

Thank you, and I look forward to future collaborations!