### PR TITLE
fix: correct bernoulli_loader kwarg, remove duplicate import, fix mutable default

### DIFF
--- a/bindsnet/encoding/loaders.py
+++ b/bindsnet/encoding/loaders.py
@@ -26,7 +26,7 @@ def bernoulli_loader(
     :param float max_prob: Maximum probability of spike per Bernoulli trial.
     """
     # Setting kwargs.
-    max_prob = kwargs.get("dt", 1.0)
+    max_prob = kwargs.get("max_prob", 1.0)
 
     for i in range(len(data)):
         # Encode datum as Bernoulli spike trains.

--- a/bindsnet/network/monitors.py
+++ b/bindsnet/network/monitors.py
@@ -4,10 +4,6 @@ from typing import TYPE_CHECKING, Dict, Iterable, Optional, Union
 
 import numpy as np
 import torch
-import numpy as np
-
-from abc import ABC
-from typing import Union, Optional, Iterable, Dict
 
 from bindsnet.network.nodes import Nodes
 from bindsnet.network.topology import (

--- a/bindsnet/network/topology.py
+++ b/bindsnet/network/topology.py
@@ -410,7 +410,7 @@ class MulticompartmentConnection(AbstractMulticompartmentConnection):
         source: Nodes,
         target: Nodes,
         device: device,
-        pipeline: list = [],
+        pipeline: Optional[list] = None,
         manual_update: bool = False,
         traces: bool = False,
         **kwargs,


### PR DESCRIPTION
## Summary

- **Fix `bernoulli_loader` reading wrong kwarg** in `bindsnet/encoding/loaders.py`: `kwargs.get("dt", 1.0)` should be `kwargs.get("max_prob", 1.0)`. The docstring documents `max_prob` as the parameter for maximum spike probability per Bernoulli trial, but the code was reading `dt` instead.

- **Remove duplicate `import numpy as np`** in `bindsnet/network/monitors.py`.

- **Fix mutable default argument** `pipeline: list = []` → `pipeline: Optional[list] = None` in `MulticompartmentConnection.__init__` (`bindsnet/network/topology.py`). Mutable defaults are shared across all instances.

## Test plan

- [ ] `bernoulli_loader` now correctly reads `max_prob` parameter
- [ ] No behavioral change for existing code that doesn't pass `max_prob` (default remains 1.0)
- [ ] Existing tests should pass without modification