### PR TITLE
chore: enable weekly Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+version: 2
+
+updates:
+  # Python dependencies, resolved through poetry.lock.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    # Minor and patch bumps arrive as a single grouped pull request so routine
+    # maintenance is one review, not twenty. Major bumps stay separate, because
+    # they need to be looked at individually.
+    groups:
+      python-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # torch and torchvision are pinned to exact versions served from the
+      # custom CUDA wheel index declared in pyproject.toml, and the two must
+      # move together. Routine version bumps here would break that pairing or
+      # silently pull the plain PyPI build instead, so they are upgraded by
+      # hand. These conditions cover version updates only; Dependabot security
+      # alerts for torch and torchvision still come through.
+      - dependency-name: "torch"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      - dependency-name: "torchvision"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+
+  # Keep the GitHub Actions used by CI current. Action versions are a supply
+  # chain surface of their own: a compromised or abandoned action runs with
+  # access to the workflow.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Only Dependabot **security** updates ran on this repository until now. That is why `poetry.lock` drifted far enough to accumulate 12 open alerts before anyone looked, six of them a single GitPython advisory that stayed unfixed because PR #779 failed to deliver the bump (see #781).

This adds weekly version updates for two ecosystems:

| Ecosystem | Behaviour |
|---|---|
| `pip` | Minor and patch bumps arrive as **one grouped pull request**, so routine maintenance is a single review rather than twenty. Major bumps stay separate. |
| `github-actions` | Action versions are their own supply chain surface. A compromised or abandoned action runs with access to the workflow. |

`open-pull-requests-limit` is 5 per ecosystem.

### torch and torchvision are excluded from version updates

They are pinned to exact versions served from the custom CUDA wheel index declared in `pyproject.toml`, and the two have to move together. Routine bumps would either break that pairing or silently pull the plain PyPI build instead of the cu130 one, so they are upgraded by hand.

The exclusions are scoped to `version-update:semver-*` types only, which means **Dependabot security alerts for torch and torchvision still come through**. That matters: one of the 12 alerts just closed was a torch advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
