### PR TITLE
Fix AbstractFeature.degrade calling itself instead of degrade_function

### DIFF
--- a/bindsnet/network/topology_features.py
+++ b/bindsnet/network/topology_features.py
@@ -291,7 +291,7 @@ class AbstractFeature(ABC):
         be *subtracted* from the propagated spikes.
         """
 
-        return self.degrade(self.value)
+        return self.degrade_function(self.value)
 
     def link(self, parent_feature) -> None:
         # language=rst

--- a/test/network/test_connections.py
+++ b/test/network/test_connections.py
@@ -341,6 +341,15 @@ class TestMultiCompartmentConnection:
         )
         assert torch.allclose(conn.compute(s), s @ w - (0.5 * deg).sum(0), atol=1e-6)
 
+    def test_degradation_feature_degrade_applies_degrade_function(self):
+        # degrade() must hand the value to degrade_function. It used to call
+        # itself with an argument, which is a TypeError on the first call.
+        deg = torch.tensor([[0.2, 0.4], [0.6, 0.8], [0.1, 0.3]])
+        feature = tf.Degradation(
+            name="d", value=deg.clone(), degrade_function=lambda v: v * 0.5
+        )
+        assert torch.allclose(feature.degrade(), 0.5 * deg, atol=1e-6)
+
     def test_probability_feature_deterministic_bounds(self):
         # bernoulli(1) == 1 (always passes); bernoulli(0) == 0 (always blocked).
         s = torch.tensor([[1.0, 0.0, 1.0], [1.0, 1.0, 1.0]])


### PR DESCRIPTION
## Problem

`AbstractFeature.degrade` calls itself:

```python
def degrade(self) -> None:
    """
    Degrade the value of the propagated spikes according to the features value. A lambda function should be passed
    into the constructor which takes a single argument (which represent the value), and returns a value which will
    be *subtracted* from the propagated spikes.
    """

    return self.degrade(self.value)
```

`degrade` takes no arguments after `self`, so this is not even infinite recursion — it raises on the very first call, for every feature, including `Degradation`:

```python
>>> from bindsnet.network.topology_features import Degradation
>>> f = Degradation(name="d", value=torch.tensor([[0.4, 0.8]]),
...                 degrade_function=lambda v: v * 0.5)
>>> f.compute(None)
tensor([[0.2000, 0.4000]])
>>> f.degrade()
TypeError: AbstractFeature.degrade() takes 1 positional argument but 2 were given
```

No other class overrides `degrade`, so there is no code path on which it works.

## Fix

The docstring describes exactly the callable that `Degradation.__init__` stores as `degrade_function` ("a lambda ... which takes a single argument (which represent the value), and returns a value which will be *subtracted* from the propagated spikes"), and `Degradation.compute` already contains the intended form a few hundred lines below:

```python
def compute(self, s) -> Union[torch.Tensor, float, int]:
    # Subtractive offset (via degrade_function) applied to every synapse.
    if self.degrade_function is not None:
        return self.degrade_function(self.value)
    return self.value
```

So this is a one-word slip: `self.degrade(...)` → `self.degrade_function(...)`. One line changed, plus a regression test next to the existing `test_degradation_feature_output`.

```
test/network/test_connections.py  25 passed   (24 before, all still passing)
```

The new test fails on `master` with the `TypeError` above and passes with the fix.

## One thing worth your call

`degrade_function` only exists on `Degradation`, so calling `degrade()` on some other feature (`Weight`, `Mask`, …) now raises `AttributeError` instead of the current `TypeError`. That seemed like the smaller change to make, but if you would rather the method live on `Degradation` — or guard with `if self.degrade_function is not None` the way `compute` does — say the word and I will move it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
