### PR TITLE
Remove dead AbstractFeature.degrade hook

### DIFF
--- a/bindsnet/network/topology_features.py
+++ b/bindsnet/network/topology_features.py
@@ -283,16 +283,6 @@ class AbstractFeature(ABC):
                 abs_sum[abs_sum == 0] = 1.0
                 self.value *= self.norm / abs_sum
 
-    def degrade(self) -> None:
-        # language=rst
-        """
-        Degrade the value of the propagated spikes according to the features value. A lambda function should be passed
-        into the constructor which takes a single argument (which represent the value), and returns a value which will
-        be *subtracted* from the propagated spikes.
-        """
-
-        return self.degrade(self.value)
-
     def link(self, parent_feature) -> None:
         # language=rst
         """


### PR DESCRIPTION
Supersedes #792. Thanks to @Anai-Guo for finding the bug.

## What is wrong

`AbstractFeature.degrade` calls itself, passing an argument the method does not accept:

```python
def degrade(self) -> None:
    return self.degrade(self.value)
```

`degrade` takes only `self`, so this raises `TypeError` on the very first call, for every feature. It is not even infinite recursion.

## Why removing rather than fixing

`git log -L 286,295:bindsnet/network/topology_features.py` returns a single commit, 4b577e9 "Add topology_features.py". The self-call has been there since the file was created, so the method has never run successfully once.

Nothing calls it. Grepping the whole repo across all file types, the only occurrences of `degrade` as a method are the definition and the broken self-call inside it. No caller in the library, examples, tests, or docs.

It looks like an intended third per-feature lifecycle hook alongside `update` and `normalize`, which `MulticompartmentConnection` does call generically over its feature pipeline (`for f in self.pipeline: f.update(**kwargs)` and `f.normalize()` in `topology.py`). The matching `for f in self.pipeline: f.degrade()` loop was never written. Degradation ended up in `Degradation.compute` instead, which is where the pipeline applies every feature, and which already guards against `degrade_function` being `None`.

Fixing the typo would leave two spellings of the same operation, the fixed `degrade()` being the unguarded one. It would also leave a method on the abstract base that only `Degradation` can satisfy, since `degrade_function` is set solely by `Degradation.__init__` — calling `degrade()` on a `Weight` or `Mask` would still fail, just with `AttributeError`.

## Risk

None that I can find. Any downstream caller would be crashing today.

## Verification

Full suite on this branch: 83 passed. `black --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)